### PR TITLE
services' templates modified, previous didn't work on v.4.10.6

### DIFF
--- a/templates/airflow-flower.service.erb
+++ b/templates/airflow-flower.service.erb
@@ -4,9 +4,9 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-Environment="AIRFLOW_HOME=<%= @home_folder %>"
-User=<%= @user %>
-Group=<%= @group %>
+Environment="AIRFLOW_HOME=<%= scope.lookupvar('airflow::home_folder')%>"
+User=<%= scope.lookupvar('airflow::user')%>
+Group=<%= scope.lookupvar('airflow::group')%>
 Type=simple
 ExecStart=/bin/airflow flower
 KillMode=process

--- a/templates/airflow-scheduler.service.erb
+++ b/templates/airflow-scheduler.service.erb
@@ -4,15 +4,15 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-PIDFile = <%= @run_folder %>/airflow_scheduler.pid
+PIDFile = <%= scope.lookupvar('airflow::run_folder') %>/airflow_scheduler.pid
 ExecStart=/usr/bin/airflow scheduler
 ExecReload=/bin/kill -HUP $MAINPID
-Environment="AIRFLOW_HOME=<%= @home_folder %>"
+Environment="AIRFLOW_HOME=<%= scope.lookupvar('airflow::home_folder')%>"
 KillMode=process
 Restart=on-failure
 RestartSec=15s
-User=<%= @user %>
-Group=<%= @group %>
+User=<%= scope.lookupvar('airflow::user')%>
+Group=<%= scope.lookupvar('airflow::group')%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/airflow-webserver.service.erb
+++ b/templates/airflow-webserver.service.erb
@@ -4,20 +4,15 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-PIDFile = <%= @run_folder %>/airflow_webserver.pid
-ExecStart=/usr/bin/gunicorn -w <%= @gunicorn_workers %> -t 120 -b <%= @web_server_host %>:<%= @web_server_port %> airflow.www.app:cached_app()
+PIDFile = <%= scope.lookupvar('airflow::run_folder') %>/airflow_webserver.pid
+ExecStart=/usr/bin/airflow webserver
 ExecReload=/bin/kill -HUP $MAINPID
-Environment="AIRFLOW_HOME=<%= @home_folder %>"
+Environment="AIRFLOW_HOME=<%= scope.lookupvar('airflow::home_folder')%>"
 KillMode=process
 Restart=on-failure
 RestartSec=15s
-User=<%= @user %>
-Group=<%= @group %>
+User=<%= scope.lookupvar('airflow::user')%>
+Group=<%= scope.lookupvar('airflow::group')%>
 
 [Install]
 WantedBy=multi-user.target
-
-
-
-
-

--- a/templates/airflow-worker.service.erb
+++ b/templates/airflow-worker.service.erb
@@ -4,15 +4,15 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-PIDFile = <%= @run_folder %>/airflow_worker.pid
+PIDFile = <%= scope.lookupvar('airflow::run_folder') %>/airflow_worker.pid
 ExecStart=/usr/bin/airflow worker
 ExecReload=/bin/kill -HUP $MAINPID
-Environment="AIRFLOW_HOME=<%= @home_folder %>"
+Environment="AIRFLOW_HOME=<%= scope.lookupvar('airflow::home_folder')%>"
 KillMode=process
 Restart=on-failure
 RestartSec=15s
-User=<%= @user %>
-Group=<%= @group %>
+User=<%= scope.lookupvar('airflow::user')%>
+Group=<%= scope.lookupvar('airflow::group')%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hello! Have to modify erb templates for services. Previous variables declaration  style ( '@variable')  doesn't work properly in my case. I tested it on vagrant box with centos7 and puppet 4.10.6. Please consider to make a merge otherwise explain your point. Btw thanks for good work.